### PR TITLE
custom exceptions handling (WIP but more or less working)

### DIFF
--- a/src/interruttore/core.clj
+++ b/src/interruttore/core.clj
@@ -43,9 +43,9 @@
     :or    {retry-count 0
             max-retries 3}}
    ;; aliasing _result just for documentation
-   {:keys [result retry-after reason] :as _result}]
+   {::keys [result retry-after reason] :as _result}]
   (case result
-    :ok ;; everything is fine this time!
+    ::ok ;; everything is fine this time!
     ;; but maybe it was not :ok before, so be careful
     (assoc circuit
       ::status (if (= ::open status) ::semi-open ::closed)
@@ -54,11 +54,11 @@
 
     ;; in case of soft failure check how many times we have alredy RE-tried
     ;; to decide if the circuit have to be opened or if we can retry again
-    :soft-failure
+    ::soft-failure
     (if (>= retry-count max-retries)
       (assoc circuit
         ::status ::open
-        ::reason (or reason :max-retries)
+        ::reason (or reason ::max-retries)
         ::retry-count (inc retry-count)
         ::retry-after (or retry-after retry-after-ms))
       (assoc circuit
@@ -66,16 +66,59 @@
 
     ;; hard failure, STOP THE WORLD!!!
     ;; setting retry-count to max-retries to support semi-open case
-    :hard-failure
+    ::hard-failure
     (assoc circuit
       ::status ::open
-      ::reason (or reason :hard-failure)
+      ::reason (or reason ::hard-failure)
       ::retry-count max-retries
       ::retry-after (or retry-after retry-after-ms))))
 
 (comment
-  (circuit-next-state {::status ::closed} {:result :ok})
-  (circuit-next-state {::status ::closed} {:result :soft-failure})
+  (circuit-next-state {::status ::closed} {::result ::ok})
+  (circuit-next-state {::status ::closed} {::result ::soft-failure})
+  )
+
+(defn- build-exceptions-map
+  "Given two sequences, one holding soft failure exception classes,
+  the other one holding hard failure exception classes, builds a map
+  of exception-type -> :failure-mode-key; hard failure exceptions
+  have the precedence over the soft ones."
+  [hard-fail-exceptions soft-fail-exceptions]
+  (let [soft
+        (reduce (fn [acc ex]
+                  (assoc acc ex ::hard-failure))
+          {} hard-fail-exceptions)]
+    (reduce (fn [acc ex]
+              (if (contains? acc ex)
+                acc
+                (assoc acc ex ::soft-failure)))
+          soft soft-fail-exceptions)))
+
+(comment
+  (build-exceptions-map [ArithmeticException] [NullPointerException])
+  ;; =>
+  ;; {java.lang.ArithmeticException :hard-failure
+  ;;  java.lang.NullPointerException :soft-failure}
+  )
+
+(defn- exception->failure-mode
+  "Given an exception ex and an exceptions map, with each entry holding
+  [ex-type failure-mode-keyword], return the failure mode keyword associated
+  to the provided exception if a match is found otherwise return nil."
+  [ex exceptions]
+  (reduce (fn [_a [ex-class fail-mode]]
+            (when (instance? ex-class ex) (reduced fail-mode))) nil exceptions))
+
+(comment
+  (exception->failure-mode
+    (NullPointerException.)
+    (build-exceptions-map [ArithmeticException] [NullPointerException])) ;; => :soft-failure
+  (exception->failure-mode
+    (ArithmeticException.)
+    (build-exceptions-map [ArithmeticException] [NullPointerException])) ;; => :hard-failure
+  (exception->failure-mode
+    (NullPointerException.)
+    (build-exceptions-map [ArithmeticException NullPointerException] [NullPointerException])) ;; => :hard-failure
   )
 
 (defn make-circuit-breaker
@@ -87,25 +130,34 @@
    (s/optional-key :value) s/Any}
   depending on the value of the :status key one of the following things
   will happen:
-  - :ok : set the circuit state to :closed and return the value of :value
-  - :soft-failure : retry calling `wfn` at most max-retries times until:
+  - ::ok : set the circuit state to :closed and return the value of :value
+  - ::soft-failure : retry calling `wfn` at most max-retries times until:
     - a valid response is returned, then proceed as the :ok case
     - after max-retries times put the circuit in :open state, set
       :retry-after timestamp to control when to try again, and return
       an error
-  - :hard-failure : skip :soft-failure machinery, set the circuit to
-    :open state, set :retry-after timestamp and return an error
+  - ::hard-failure : skip :soft-failure machinery, set the circuit to
+    ::open state, set ::retry-after timestamp and return an error
 
   in the case `wfn` throws the :soft-failure case will be used
   "
   ([wrapped-fn]
    (make-circuit-breaker wrapped-fn {}))
   ([wrapped-fn
-    {:keys [max-retries retry-after-ms]
+    {:keys [hard-failure-exceptions soft-failure-exceptions
+            exception-failure-map
+            max-retries retry-after-ms]
      :or
-     {max-retries 3
+     {soft-failure-exceptions [Throwable]
+      hard-failure-exceptions []
+      max-retries 3
       retry-after-ms 10}}]
-   (let [circuit_ (atom {::retry-count 0
+   (let [exceptions
+         (or
+           exception-failure-map
+           (build-exceptions-map hard-failure-exceptions soft-failure-exceptions))
+         ex->failure-mode (memoize exception->failure-mode) ;; ALERT! premature optimization
+         circuit_ (atom {::retry-count 0
                          ::retry-after nil
                          ::retry-after-ms retry-after-ms
                          ::max-retries max-retries
@@ -114,16 +166,24 @@
        (fn [& args]
          (if (circuit-open? @circuit_)
            ;; circuit still open, fail early
-           {:status :open
-            :retry-after (::retry-after @circuit_)}
+           {::status :open
+            ::retry-after (::retry-after @circuit_)}
            ;; circuit not open, try to call wrapped-fn and handle the result
            (loop []
-             (let [{:keys [result value] :as res}
+             (let [{::keys [result value] :as res}
                    (try
-                     (apply wrapped-fn args)
+                     (let [res (apply wrapped-fn args)]
+                       (if (and (map? res) (contains? res ::result))
+                         res
+                         {::result ::ok
+                          ::value res}))
+
                      (catch Throwable t
-                       ;; exception are considered as soft-failure
-                       {:result :soft-failure}))]
+                       (if-let [failure-mode (ex->failure-mode t exceptions)]
+                         {::result failure-mode}
+                         ;; un-handled exception, re-throw
+                         (throw t))
+                       ))]
                ;; evaluate result and prev state to calculate next state
                (swap! circuit_ #(circuit-next-state % res))
 
@@ -131,12 +191,12 @@
                  (cond
                    (= ::open status)
                    ;; wrapped-fn failed too many times
-                   {:status :open
-                    :reason reason
-                    :retry-after retry-after}
+                   {::status ::open
+                    ::reason reason
+                    ::retry-after retry-after}
 
                    ;; wrapped-fn did not return ok, sleep a bit and retry
-                   (not (= :ok result))
+                   (not (= ::ok result))
                    (do
                      (Thread/sleep (* retry-after-ms (inc retry-count)))
                      (recur))
@@ -144,8 +204,8 @@
                    ;; wrapped-fn was successful, status can be ::closed
                    ;; or ::semi-open
                    :else
-                   {:status (if (= ::closed status) :closed :semi-open)
-                    :value value}
+                   {::status status
+                    ::value value}
                    ))))))
        {:circuit_ circuit_}))))
 

--- a/test/interruttore/core_test.clj
+++ b/test/interruttore/core_test.clj
@@ -10,11 +10,42 @@
 
 ;; testing internal API
 
+(deftest build-exception-map
+  (testing "Provided two sequenques for hard and soft failures return a map
+of exception -> failure mode"
+    (is (= {NullPointerException ::cb/hard-failure
+            ArithmeticException ::cb/soft-failure}
+          (#'cb/build-exceptions-map
+            [NullPointerException]
+            [ArithmeticException]))))
+  (testing "If the same exception type is provided for hard and soft failures,
+hard one wins"
+    (is (= {NullPointerException ::cb/hard-failure
+            ArithmeticException ::cb/hard-failure}
+          (#'cb/build-exceptions-map
+            [NullPointerException ArithmeticException]
+            [NullPointerException])))))
+
+(def exceptions-map (#'cb/build-exceptions-map
+                      [NullPointerException]
+                      [ArithmeticException]))
+
+(deftest exception->failure-mode
+  (testing "Return the failure mode associated with an exception, soft"
+    (is (= ::cb/soft-failure
+          (#'cb/exception->failure-mode (ArithmeticException.) exceptions-map))))
+  (testing "Return the failure mode associated with an exception, hard"
+    (is (= ::cb/hard-failure
+          (#'cb/exception->failure-mode (NullPointerException.) exceptions-map))))
+  (testing "Return the failure mode associated with an exception, no match"
+    (is (nil?
+          (#'cb/exception->failure-mode (Exception.) exceptions-map)))))
+
 (deftest circuit-open?
   (testing "Circuit not open when ::closed :)"
-    (is (false? (cb/circuit-open? {::status ::closed}))))
+    (is (false? (cb/circuit-open? {::cb/status ::cb/closed}))))
   (testing "Circuit not open when ::semi-open"
-    (is (false? (cb/circuit-open? {::status ::semi-open}))))
+    (is (false? (cb/circuit-open? {::cb/status ::cb/semi-open}))))
   (testing "Circuit not open when ::status ::open and ::retry-after is expired"
     (is (false? (cb/circuit-open?
                   {::cb/status ::cb/open
@@ -29,14 +60,14 @@
     (is (= {::cb/status ::cb/closed
             ::cb/retry-after nil
             ::cb/retry-count 0}
-          (#'cb/circuit-next-state {::cb/status ::cb/closed} {:result :ok}))))
+          (#'cb/circuit-next-state {::cb/status ::cb/closed} {::cb/result ::cb/ok}))))
   (testing "Circuit ::closed, first :soft-failure, inc ::retry-count to 1"
     (is (= {::cb/status ::cb/closed
             ::cb/retry-count 1}
-          (#'cb/circuit-next-state {::cb/status ::cb/closed} {:result :soft-failure}))))
+          (#'cb/circuit-next-state {::cb/status ::cb/closed} {::cb/result ::cb/soft-failure}))))
   (testing "Circuit ::closed, last :soft-failure, set to ::open"
     (is (= {::cb/status ::cb/open
-            ::cb/reason :max-retries
+            ::cb/reason ::cb/max-retries
             ::cb/retry-after 3
             ::cb/max-retries 1
             ::cb/retry-count 2}
@@ -44,8 +75,8 @@
             {::cb/status ::cb/closed
              ::cb/max-retries 1
              ::cb/retry-count 1}
-            {:result :soft-failure
-             :retry-after 3}))))
+            {::cb/result ::cb/soft-failure
+             ::cb/retry-after 3}))))
   (testing "Circuit ::closed, last :soft-failure, provide reason"
     (is (= {::cb/status ::cb/open
             ::cb/reason :provided-reason
@@ -56,9 +87,9 @@
             {::cb/status ::cb/closed
              ::cb/max-retries 1
              ::cb/retry-count 1}
-            {:result :soft-failure
-             :reason :provided-reason
-             :retry-after 3}))))
+            {::cb/result ::cb/soft-failure
+             ::cb/reason :provided-reason
+             ::cb/retry-after 3}))))
   (testing "Circuit ::open, result :ok, set to ::semi-open"
     (is (= {::cb/status ::cb/semi-open
             ::cb/retry-after nil
@@ -68,7 +99,7 @@
             {::cb/status ::cb/open
              ::cb/max-retries 1
              ::cb/retry-count 1}
-            {:result :ok}))))
+            {::cb/result ::cb/ok}))))
   (testing "Circuit ::semi-open, result :ok, set to ::closed"
     (is (= {::cb/status ::cb/closed
             ::cb/retry-after nil
@@ -78,10 +109,10 @@
             {::cb/status ::cb/semi-open
              ::cb/max-retries 1
              ::cb/retry-count 1}
-            {:result :ok}))))
+            {::cb/result ::cb/ok}))))
   (testing "Circuit ::closed, first :hard-failure, set to ::open"
     (is (= {::cb/status ::cb/open
-            ::cb/reason :hard-failure
+            ::cb/reason ::cb/hard-failure
             ::cb/retry-after 5
             ::cb/max-retries 3
             ::cb/retry-count 3}
@@ -89,8 +120,8 @@
             {::cb/status ::cb/closed
              ::cb/max-retries 3
              ::cb/retry-count 1}
-            {:result :hard-failure
-             :retry-after 5}))))
+            {::cb/result ::cb/hard-failure
+             ::cb/retry-after 5}))))
   (testing "Circuit ::closed, first :hard-failure, provide :reason"
     (is (= {::cb/status ::cb/open
             ::cb/reason :provided-reason
@@ -101,54 +132,104 @@
             {::cb/status ::cb/closed
              ::cb/max-retries 3
              ::cb/retry-count 1}
-            {:result :hard-failure
-             :reason :provided-reason
-             :retry-after 5}))))
+            {::cb/result ::cb/hard-failure
+             ::cb/reason :provided-reason
+             ::cb/retry-after 5}))))
   )
 
 ;; testing public API
+
+;; Return based
 (defn wrapped-helper
   "This helper should make it easy to simulate return values
   of a wrapped function"
   ([result value]
    (wrapped-helper result value nil))
   ([result value retry-after]
-   {:result result
-    :value value
-    :retry-after retry-after}))
+   {::cb/result result
+    ::cb/value value
+    ::cb/retry-after retry-after}))
 
 (def wrapped (cb/make-circuit-breaker wrapped-helper))
 
 (deftest circuit-breaker-api
   (testing "Circuit closed, result :ok"
-    (is (= {:status :closed
-            :value 1}
-           (wrapped :ok 1))))
+    (is (= {::cb/status ::cb/closed
+            ::cb/value 1}
+           (wrapped ::cb/ok 1))))
   (testing "Circuit closed, result :soft-failure"
+    (is (= {::cb/status ::cb/open
+            ::cb/reason ::cb/max-retries
+            ::cb/retry-after "after"}
+           (wrapped ::cb/soft-failure 1 "after"))))
+  (testing "Circuit open, next call :ok, status :semi-open"
+    (is (= {::cb/status ::cb/semi-open
+            ::cb/value 1}
+          (do
+            (cb/reset wrapped)
+            (wrapped ::cb/soft-failure 1 (now)) ;; open the circuit
+            (wrapped ::cb/ok 1)))))
+  (testing "Circuit semi-open, next call :ok, status :closed"
+    (is (= {::cb/status ::cb/closed
+            ::cb/value 1}
+          (do
+            (cb/reset wrapped)
+            (wrapped ::cb/soft-failure 1 (now)) ;; open the circuit
+            (wrapped ::cb/ok 1) ;; here the status is :semi-open
+            (wrapped ::cb/ok 1)))))
+  (testing "Circuit closed, result :hard-failure"
+    (is (= {::cb/status ::cb/open
+            ::cb/reason ::cb/hard-failure
+            ::cb/retry-after "after"}
+          (do
+            (cb/reset wrapped)
+            (wrapped ::cb/hard-failure 1 "after")))))
+)
+
+;; Exception based
+(defn raise-exception
+  "This helper should make it easy to simulate exceptions"
+  ([value] (raise-exception value nil))
+  ([value ex]
+   (if (not (nil? ex))
+     (throw ex)
+     value)))
+
+(def ex-wrapped (cb/make-circuit-breaker
+                  raise-exception
+                  {:hard-failure-exceptions [NullPointerException]
+                   :soft-failure-exceptions [ArithmeticException]}))
+
+(deftest circuit-breaker-exception-api
+  (testing "Circuit closed, result :ok"
+    (is (= {::cb/status ::cb/closed
+            ::cb/value 1}
+           (ex-wrapped 1))))
+  #_(testing "Circuit closed, result :soft-failure"
     (is (= {:status :open
             :reason :max-retries
             :retry-after "after"}
-           (wrapped :soft-failure 1 "after"))))
-  (testing "Circuit open, next call :ok, status :semi-open"
+           (ex-wrapped 1 (ArithmeticException.)))))
+  #_(testing "Circuit open, next call :ok, status :semi-open"
     (is (= {:status :semi-open
             :value 1}
           (do
-            (cb/reset wrapped)
-            (wrapped :soft-failure 1 (now)) ;; open the circuit
-            (wrapped :ok 1)))))
-  (testing "Circuit semi-open, next call :ok, status :closed"
+            (cb/reset ex-wrapped)
+            (ex-wrapped 1 (ArithmeticException.)) ;; open the circuit
+            (ex-wrapped 1)))))
+  #_(testing "Circuit semi-open, next call :ok, status :closed"
     (is (= {:status :closed
             :value 1}
           (do
-            (cb/reset wrapped)
-            (wrapped :soft-failure 1 (now)) ;; open the circuit
-            (wrapped :ok 1) ;; here the status is :semi-open
-            (wrapped :ok 1)))))
-  (testing "Circuit closed, result :hard-failure"
+            (cb/reset ex-wrapped)
+            (ex-wrapped 1 (ArithmeticException.)) ;; open the circuit
+            (ex-wrapped 1) ;; here the status is :semi-open
+            (ex-wrapped 1)))))
+  #_(testing "Circuit closed, result :hard-failure"
     (is (= {:status :open
             :reason :hard-failure
             :retry-after "after"}
           (do
-            (cb/reset wrapped)
-            (wrapped :hard-failure 1 "after")))))
+            (cb/reset ex-wrapped)
+            (ex-wrapped 1 (NullPointerException.))))))
 )


### PR DESCRIPTION
Issue #8 

I have added a lot of complexity with no clear benefit.
Using exceptions as a fallback mechanism may be enough for this
library while focusing on the features of the return based approach.
It would be nice, anyway, to add support for custom exceptions for
the soft failure case.
Even in the case of exceptions, the wrapped function is expected to
based on the return approach, if it runs succesfuly it must return
a map with at least :result and :value keys.